### PR TITLE
Write a new post 'Go on ARM and Beyond - The Go Blog 日本語翻訳'

### DIFF
--- a/content/post/2020-12-20 .md
+++ b/content/post/2020-12-20 .md
@@ -1,5 +1,5 @@
 ---
-title: "Go on ARM and Beyond - The Go Blog"
+title: "Go on ARM and Beyond - The Go Blog 日本語翻訳"
 date: 2020-12-20T18:00:00+09:00
 tags: [reading, golang]
 toc: yes
@@ -10,89 +10,41 @@ slug: go-blog-ports
 
 <!--more-->
 
-# Go on ARM and Beyond
+## Japanese translation
 
-17 Dec 2020
-Summary: Go's support for ARM64 and other architectures
+- Date: 17 Dec 2020
+- Summary: GoのARM64とその他のアーキテクチャへの対応
+- Auther: Russ Cox
 
-Russ Cox
+最近、業界ではnon-x86なプロセッサが話題になっています。そのため、non-x86なプロセッサに対するGoのサポートについて簡単な記事を書く価値があると考えました。
 
-##
+Goがポータブルで、特定のオペレーティングシステムやアーキテクチャに過度に依存しないことは、私たちにとって常に重要なことでした。[Goの最初のオープンソースのリリース](https://opensource.googleblog.com/2009/11/hey-ho-lets-go.html)時点で、Goは2種類のオペレーティングシステム（LinuxとMac OS X）と3種類のアーキテクチャ（64-bit x86，32-bit x86、32-bit ARM）をサポートしていました。
 
-The industry is abuzz about non-x86 processors recently,
-so we thought it would be worth a brief post about Go’s support for them.
+以下のように、年々、多数のオペレーティングシステムとアーキテクチャの組み合わせへのサポートを追加してきました。
 
-It has always been important to us for Go to be portable,
-not overfitting to any particular operating system or architecture.
-The [initial open source release of Go](https://opensource.googleblog.com/2009/11/hey-ho-lets-go.html)
-included support for two operating systems (Linux and Mac OS X) and three
-architectures (64-bit x86,
-32-bit x86, and 32-bit ARM).
+- Go 1 (2012年3月) では、64-bitおよび32-bitのx86上のFreeBSD、NetBSD、OpenBSD、32-bit x86上のPlan 9を含むオリジナルシステムのサポートを追加しました。
+- Go 1.3 (2014年6月) では、64-bit x86上のSolarisのサポートを追加しました。
+- Go 1.4 (2014年12月) では、32-bit ARM上のAndroidと64-bit x86上のPlan 9のサポートを追加しました。
+- Go 1.5 (2015年8月) では、64-bit ARMおよび64-bit PowerPC上のLinuxと、32-bitと64-bit ARM上のiOSのサポートを追加しました。
+- Go 1.6 (2016年2月) では、64-bit MIPS上のLinux、32-bit x86上のAndroidへのサポートを追加しました。また、特にRaspberry Piシステム向けの32-bit ARM上のLinuxに対する公式バイナリのダウンロードも追加しました。
+- Go 1.7 (2016年8月) では、z Systems (S390x)上のLinuxと32-bit ARM上のPlan 9へのサポートを追加しました。
+- Go 1.8 (2017年2月) では、32-bit MIPS上のLinuxへのサポートを追加と、64-bit PowerPCおよびz Systems上のLinuxに対する公式バイナリのダウンロードを追加しました。
+- Go 1.9 (2017年8月) では、64-bit ARM上のLinuxに対する公式バイナリのダウンロードを追加しました。
+- Go 1.12 (2018年2月) では、Raspberry Pi 3などの32-bit ARM上のWindows 10 IoT Coreのサポートを追加しました。 また、64-bit PowerPC上のAIXのサポートも追加しました。
+- Go 1.14 (2019年2月) では、64-bit RISC-V上のLinuxのサポートを追加しました。
 
-Over the years, we’ve added support for many more operating systems and architecture combinations:
+初期のGoでは、x86-64のポートが最も注目を集めましたが、最近のGoのターゲットアーキテクチャは私たちの[SSA-based compiler back end](https://www.youtube.com/watch?v=uTMvKVma5ms)でよくサポートされており、素晴らしいコードが生成されるようになっています。私たちは、Amazon、ARM、Atos、IBM、Intel、MIPSのエンジニアを含む多数のコントリビューターに助けられてきました。
 
-- Go 1 (March 2012) supported the original systems as well as FreeBSD,
-  NetBSD, and OpenBSD on 64-bit and 32-bit x86,
-  and Plan 9 on 32-bit x86.
-- Go 1.3 (June 2014) added support for Solaris on 64-bit x86.
-- Go 1.4 (December 2014) added support for Android on 32-bit ARM and Plan 9 on 64-bit x86.
-- Go 1.5 (August 2015) added support for Linux on 64-bit ARM and 64-bit PowerPC,
-  as well as iOS on 32-bit and 64-bit ARM.
-- Go 1.6 (February 2016) added support for Linux on 64-bit MIPS,
-  as well as Android on 32-bit x86.
-  It also added an official binary download for Linux on 32-bit ARM,
-  primarily for Raspberry Pi systems.
-- Go 1.7 (August 2016) added support for Linux on z Systems (S390x) and Plan 9 on 32-bit ARM.
-- Go 1.8 (February 2017) added support for Linux on 32-bit MIPS,
-  and it added official binary downloads for Linux on 64-bit PowerPC and z Systems.
-- Go 1.9 (August 2017) added official binary downloads for Linux on 64-bit ARM.
-- Go 1.12 (February 2018) added support for Windows 10 IoT Core on 32-bit ARM,
-  such as the Raspberry Pi 3.
-  It also added support for AIX on 64-bit PowerPC.
-- Go 1.14 (February 2019) added support for Linux on 64-bit RISC-V.
+Goは初期状態で最小限の作業を行うだけで、これらすべてのシステムに対するクロスコンパイルをサポートしています。たとえば、32-bitのx86ベースのWindows向けのアプリを64-bit Linuxシステム上でビルドするには、次のコマンドを実行するだけで行えます。
 
-Although the x86-64 port got most of the attention in the early days of Go,
-today all our target architectures are well supported by our [SSA-based compiler back end](https://www.youtube.com/watch?v=uTMvKVma5ms)
-and produce excellent code.
-We’ve been helped along the way by many contributors,
-including engineers from Amazon, ARM, Atos,
-IBM, Intel, and MIPS.
+```shell
+GOARCH=386 GOOS=windows go build myapp  # writes myapp.exe
+```
 
-Go supports cross-compiling for all these systems out of the box with minimal effort.
-For example, to build an app for 32-bit x86-based Windows from a 64-bit Linux system:
+去年、複数のメジャーなベンダーがサーバー、ラップトップ、開発用マシン向けの新しいARM64ハードウェアを発表しました。Goはこうした状況に対して良いポジションにいました。現在まで、GoはARM64のLinuxサーバーやARM64のAndroidとiOSデバイス上のモバイルアプリで、Docker、Kubernetes、その他のGoエコシステムのプログラムを支えてきました。
 
-	GOARCH=386 GOOS=windows go build myapp  # writes myapp.exe
+この夏にAppleがMacのApple Siliconへの移行を発表して以来、Goと幅広いGoエコシステムがRosetta 2上のGo x86バイナリとネイティブのGo ARM64バイナリでの動作を保証できるように、AppleとGoogleは協力して作業してきました。今週のはじめに、最初のGo 1.16 betaをリリースしました。これには、M1チップを使用しているMacに対するネイティブのサポートが含まれています。Go 1.16 betaは、M1 Macとその他のすべてのシステムで[Go download page](https://golang.org/dl/#go1.16beta1)からダウンロードして試すことができます。(もちろん、こればbetaリリースなので、すべてのbetaと同様にまだ明らかになっていないバグが含まれているはずです。何らかの問題を見つけたときは、ぜひ[golang.org/issue/new](https://golang.org/issue/new)で報告してください。)
 
-In the past year, several major vendors have made announcements of new ARM64
-hardware for servers,
-laptops and developer machines.
-Go was well-positioned for this. For years now,
-Go has been powering Docker, Kubernetes, and the rest of the Go ecosystem
-on ARM64 Linux servers,
-as well as mobile apps on ARM64 Android and iOS devices.
+2つの環境の差異をなくすために、ローカルの開発を本番環境と同一のアーキテクチャで行うのは常によいことです。ARM64の本番環境にデプロイする場合、GoではARM64 LinuxおよびMacのシステムで開発を行うことも簡単です。しかしもちろん、x86システムで作業してARMにデプロイする場合でも、Windowsで開発してLinuxにデプロイする場合でも、あるいはそれ以外の組み合わせでも、1つのシステムで作業して別のシステム向けにクロスコンパイルするのはいつになく簡単になっています。
 
-Since Apple’s announcement of the Mac transitioning to Apple silicon this summer,
-Apple and Google have been working together to ensure that Go and the broader
-Go ecosystem work well on them,
-both running Go x86 binaries under Rosetta 2 and running native Go ARM64 binaries.
-Earlier this week, we released the first Go 1.16 beta,
-which includes native support for Macs using the M1 chip.
-You can download and try the Go 1.16 beta for M1 Macs and all your other
-systems on [the Go download page](https://golang.org/dl/#go1.16beta1).
-(Of course, this is a beta release and, like all betas,
-it certainly has bugs we don’t know about.
-If you run into any problems, please report them at [golang.org/issue/new](https://golang.org/issue/new).)
-
-It’s always nice to use the same CPU architecture for local development as in production,
-to remove one variation between the two environments.
-If you deploy to ARM64 production servers,
-Go makes it easy to develop on ARM64 Linux and Mac systems too.
-But of course, it’s still as easy as ever to work on one system and cross-compile
-for deployment to another,
-whether you’re working on an x86 system and deploying to ARM,
-working on Windows and deploying to Linux,
-or some other combination.
-
-The next target we’d like to add support for is ARM64 Windows 10 systems.
-If you have expertise and would like to help,
-we’re coordinating work on [golang.org/issue/36439](https://github.com/golang/go/issues/36439).
+私たちがサポートを追加しようとしている次の目標は、ARM64のWindows 10システムです。もしあなたが専門知識を持っていて支援したい場合は、[golang.org/issue/36439](https://github.com/golang/go/issues/36439)で作業を調整してます。

--- a/content/post/2020-12-20 .md
+++ b/content/post/2020-12-20 .md
@@ -1,0 +1,98 @@
+---
+title: "Go on ARM and Beyond - The Go Blog"
+date: 2020-12-20T18:00:00+09:00
+tags: [reading, golang]
+toc: yes
+slug: go-blog-ports
+---
+
+[Go on ARM and Beyond - The Go Blog](https://blog.golang.org/ports)の翻訳です。元の記事のソースは[blog/ports.article at master · golang/blog](https://github.com/golang/blog/blob/master/content/ports.article)にあり、[Creative Commons — CC BY 3.0](https://creativecommons.org/licenses/by/3.0/)で[ライセンス](https://golang.org/doc/copyright.html)されています。
+
+<!--more-->
+
+# Go on ARM and Beyond
+
+17 Dec 2020
+Summary: Go's support for ARM64 and other architectures
+
+Russ Cox
+
+##
+
+The industry is abuzz about non-x86 processors recently,
+so we thought it would be worth a brief post about Go’s support for them.
+
+It has always been important to us for Go to be portable,
+not overfitting to any particular operating system or architecture.
+The [initial open source release of Go](https://opensource.googleblog.com/2009/11/hey-ho-lets-go.html)
+included support for two operating systems (Linux and Mac OS X) and three
+architectures (64-bit x86,
+32-bit x86, and 32-bit ARM).
+
+Over the years, we’ve added support for many more operating systems and architecture combinations:
+
+- Go 1 (March 2012) supported the original systems as well as FreeBSD,
+  NetBSD, and OpenBSD on 64-bit and 32-bit x86,
+  and Plan 9 on 32-bit x86.
+- Go 1.3 (June 2014) added support for Solaris on 64-bit x86.
+- Go 1.4 (December 2014) added support for Android on 32-bit ARM and Plan 9 on 64-bit x86.
+- Go 1.5 (August 2015) added support for Linux on 64-bit ARM and 64-bit PowerPC,
+  as well as iOS on 32-bit and 64-bit ARM.
+- Go 1.6 (February 2016) added support for Linux on 64-bit MIPS,
+  as well as Android on 32-bit x86.
+  It also added an official binary download for Linux on 32-bit ARM,
+  primarily for Raspberry Pi systems.
+- Go 1.7 (August 2016) added support for Linux on z Systems (S390x) and Plan 9 on 32-bit ARM.
+- Go 1.8 (February 2017) added support for Linux on 32-bit MIPS,
+  and it added official binary downloads for Linux on 64-bit PowerPC and z Systems.
+- Go 1.9 (August 2017) added official binary downloads for Linux on 64-bit ARM.
+- Go 1.12 (February 2018) added support for Windows 10 IoT Core on 32-bit ARM,
+  such as the Raspberry Pi 3.
+  It also added support for AIX on 64-bit PowerPC.
+- Go 1.14 (February 2019) added support for Linux on 64-bit RISC-V.
+
+Although the x86-64 port got most of the attention in the early days of Go,
+today all our target architectures are well supported by our [SSA-based compiler back end](https://www.youtube.com/watch?v=uTMvKVma5ms)
+and produce excellent code.
+We’ve been helped along the way by many contributors,
+including engineers from Amazon, ARM, Atos,
+IBM, Intel, and MIPS.
+
+Go supports cross-compiling for all these systems out of the box with minimal effort.
+For example, to build an app for 32-bit x86-based Windows from a 64-bit Linux system:
+
+	GOARCH=386 GOOS=windows go build myapp  # writes myapp.exe
+
+In the past year, several major vendors have made announcements of new ARM64
+hardware for servers,
+laptops and developer machines.
+Go was well-positioned for this. For years now,
+Go has been powering Docker, Kubernetes, and the rest of the Go ecosystem
+on ARM64 Linux servers,
+as well as mobile apps on ARM64 Android and iOS devices.
+
+Since Apple’s announcement of the Mac transitioning to Apple silicon this summer,
+Apple and Google have been working together to ensure that Go and the broader
+Go ecosystem work well on them,
+both running Go x86 binaries under Rosetta 2 and running native Go ARM64 binaries.
+Earlier this week, we released the first Go 1.16 beta,
+which includes native support for Macs using the M1 chip.
+You can download and try the Go 1.16 beta for M1 Macs and all your other
+systems on [the Go download page](https://golang.org/dl/#go1.16beta1).
+(Of course, this is a beta release and, like all betas,
+it certainly has bugs we don’t know about.
+If you run into any problems, please report them at [golang.org/issue/new](https://golang.org/issue/new).)
+
+It’s always nice to use the same CPU architecture for local development as in production,
+to remove one variation between the two environments.
+If you deploy to ARM64 production servers,
+Go makes it easy to develop on ARM64 Linux and Mac systems too.
+But of course, it’s still as easy as ever to work on one system and cross-compile
+for deployment to another,
+whether you’re working on an x86 system and deploying to ARM,
+working on Windows and deploying to Linux,
+or some other combination.
+
+The next target we’d like to add support for is ARM64 Windows 10 systems.
+If you have expertise and would like to help,
+we’re coordinating work on [golang.org/issue/36439](https://github.com/golang/go/issues/36439).


### PR DESCRIPTION
This change adds a new post, which is a Japanese translation of a Go blog post: [Go on ARM and Beyond - The Go Blog](https://blog.golang.org/ports).